### PR TITLE
Moves default gradle tasks into project root

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,6 @@ apply plugin: 'crashlytics'
 apply plugin: 'android-test'
 apply plugin: 'android-cq'
 
-defaultTasks = ['clean', 'test', 'checkstyle', 'pmd']
-
 repositories {
     mavenCentral()
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -5,4 +5,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:0.7.+'
     }
+
+    defaultTasks = ['clean', 'test', 'checkstyle', 'pmd']
 }


### PR DESCRIPTION
Running the default "gradle" command in the app folder currently produces the following error:

Execution failed for task ':app:checkstyle'.

> Unable to create a Checker: cannot initialize module SuppressionFilter - Cannot set property 'file' in module SuppressionFilter to 'app/cq-configs/checkstyle/checkstyle-suppressions.xml': unable to find app/cq-configs/checkstyle/checkstyle-suppressions.xml

Moving the default tasks into the root build.gradle file allows the gradle command to be run
from the project root without problems and still executes all default  tasks on the module "app".
