### PR TITLE
Fixes search weirdness (take 2).

### DIFF
--- a/app/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/app/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -131,12 +131,12 @@ public class BaseActivity extends MapActivity {
 
     private OnConnectionFailedListener onConnectionFailedListener =
             new OnConnectionFailedListener() {
-        @Override
-        public void onConnectionFailed(ConnectionResult connectionResult) {
-            Toast.makeText(getApplicationContext(),
-                    PLAY_SERVICE_FAIL_MESSAGE, Toast.LENGTH_LONG).show();
-        }
-    };
+                @Override
+                public void onConnectionFailed(ConnectionResult connectionResult) {
+                    Toast.makeText(getApplicationContext(),
+                            PLAY_SERVICE_FAIL_MESSAGE, Toast.LENGTH_LONG).show();
+                }
+            };
 
     private void initLocationClient() {
         Logger.d("Location: initializing");
@@ -187,7 +187,8 @@ public class BaseActivity extends MapActivity {
                         getSupportFragmentManager().findFragmentByTag(ListResultsFragment.TAG);
                 if (pagerResultsFragment != null && pagerResultsFragment.isAdded()
                         && listResultsFragment == null) {
-                    onBackPressed();
+                    getSupportFragmentManager().beginTransaction().remove(pagerResultsFragment)
+                            .commit();
                 }
                 return true;
             }
@@ -312,14 +313,10 @@ public class BaseActivity extends MapActivity {
 
     public boolean executeSearchOnMap(String query) {
         PagerResultsFragment pagerResultsFragment = PagerResultsFragment.newInstance(this);
-
-        if (!pagerResultsFragment.isAdded()) {
-            getSupportFragmentManager().beginTransaction()
-                    .addToBackStack(null)
-                    .add(R.id.pager_results_container, pagerResultsFragment,
-                            PagerResultsFragment.TAG)
-                    .commit();
-        }
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.pager_results_container, pagerResultsFragment,
+                        PagerResultsFragment.TAG)
+                .commit();
 
         return pagerResultsFragment.executeSearchOnMap(getSearchView(), query);
     }

--- a/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -13,7 +13,6 @@ import com.mapzen.fragment.PagerResultsFragment;
 import com.mapzen.shadows.ShadowLocationClient;
 import com.mapzen.shadows.ShadowVolley;
 import com.mapzen.support.MapzenTestRunner;
-import com.mapzen.support.TestBaseActivity;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -129,20 +128,37 @@ public class BaseActivityTest {
     public void onMenuItemActionCollapse_shouldPopPagerResultsFragment() throws Exception {
         activity.executeSearchOnMap("query");
         menu.findItem(R.id.search).collapseActionView();
-        assertThat(((TestBaseActivity) activity).isBackPressed()).isTrue();
+        assertThat(activity.getSupportFragmentManager())
+                .doesNotHaveFragmentWithTag(PagerResultsFragment.TAG);
     }
 
     @Test
-    public void executeSearchOnMap_shouldCreateNewPagerResultsFragmentEachTime() throws Exception {
+    public void executeSearchOnMap_shouldCreateNewPagerResultsFragment() throws Exception {
         activity.executeSearchOnMap("query1");
         final PagerResultsFragment fragment1 = (PagerResultsFragment)
                 activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG);
 
-        activity.executeSearchOnMap("query1");
+        activity.executeSearchOnMap("query2");
         final PagerResultsFragment fragment2 = (PagerResultsFragment)
                 activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG);
 
         assertThat(fragment1).isNotSameAs(fragment2);
+    }
+
+    @Test
+    public void executeSearchOnMap_shouldReplaceExistingFragment() throws Exception {
+        activity.executeSearchOnMap("query1");
+        final PagerResultsFragment fragment1 = (PagerResultsFragment)
+                activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG);
+
+        activity.executeSearchOnMap("query2");
+        final PagerResultsFragment fragment2 = (PagerResultsFragment)
+                activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG);
+
+        assertThat(activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG))
+                .isNotSameAs(fragment1);
+        assertThat(activity.getSupportFragmentManager().findFragmentByTag(PagerResultsFragment.TAG))
+                .isSameAs(fragment2);
     }
 
     @Test


### PR DESCRIPTION
- Updates search results when performing a second search while first is still showing on the screen.
- Uses .replace() to ensure new results fragment is shown each time and does not add transaction to back stack.
- Explicitly removes pager results fragment when search is collapsed rather than relying onBackPressed().
