### PR TITLE
Fixes test errors resulting from vtm-android update.

### DIFF
--- a/app/src/main/java/com/mapzen/entity/Feature.java
+++ b/app/src/main/java/com/mapzen/entity/Feature.java
@@ -48,7 +48,8 @@ public class Feature extends GeoFeature implements Parcelable {
 
     public MarkerItem getMarker() {
         GeoPoint geoPoint = new GeoPoint(getLat(), getLon());
-        MarkerItem markerItem = new MarkerItem(this, getProperty(NAME), "Current Location", geoPoint);
+        MarkerItem markerItem = new MarkerItem(this, getProperty(NAME),
+                "Current Location", geoPoint);
         return markerItem;
     }
 

--- a/app/src/main/java/com/mapzen/fragment/MapFragment.java
+++ b/app/src/main/java/com/mapzen/fragment/MapFragment.java
@@ -80,12 +80,13 @@ public class MapFragment extends BaseFragment {
 
     public void centerOn(Feature feature, double zoom) {
         MarkerItem focused = poiMarkersLayer.getFocus();
-        if (focused != null)
+        if (focused != null) {
             focused.setMarker(null);
+        }
 
         focused = poiMarkersLayer.getByUid(feature);
 
-        if (focused != null){
+        if (focused != null) {
             focused.setMarker(highlightMarker);
             poiMarkersLayer.setFocus(focused);
         }

--- a/app/src/test/java/com/mapzen/MapzenApplicationTest.java
+++ b/app/src/test/java/com/mapzen/MapzenApplicationTest.java
@@ -11,9 +11,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class MapzenApplicationTest {
     private MapzenApplication app;

--- a/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 import org.robolectric.tester.android.view.TestMenu;
 
 import static com.mapzen.support.TestHelper.initBaseActivity;
@@ -30,6 +31,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.application;
 import static org.robolectric.util.FragmentTestUtil.startFragment;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class BaseActivityTest {
     private BaseActivity activity;

--- a/app/src/test/java/com/mapzen/entity/FeatureTest.java
+++ b/app/src/test/java/com/mapzen/entity/FeatureTest.java
@@ -7,11 +7,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(RobolectricTestRunner.class)
 public class FeatureTest {
     private Feature feature = new Feature();

--- a/app/src/test/java/com/mapzen/fragment/DirectionListFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/DirectionListFragmentTest.java
@@ -14,6 +14,7 @@ import com.mapzen.widget.DistanceView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 
@@ -22,6 +23,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.application;
 import static org.robolectric.util.FragmentTestUtil.startFragment;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class DirectionListFragmentTest {
     private DirectionListFragment fragment;

--- a/app/src/test/java/com/mapzen/fragment/ItemFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/ItemFragmentTest.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
 import org.robolectric.util.FragmentTestUtil;
 
@@ -26,6 +27,7 @@ import static com.mapzen.support.TestHelper.initMapFragment;
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class ItemFragmentTest {
     private BaseActivity act;

--- a/app/src/test/java/com/mapzen/fragment/ListResultsFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/ListResultsFragmentTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 import org.robolectric.tester.android.view.TestMenu;
 import org.robolectric.tester.android.view.TestMenuItem;
 
@@ -22,6 +23,7 @@ import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.util.FragmentTestUtil.startFragment;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class ListResultsFragmentTest {
     private ListResultsFragment fragment;

--- a/app/src/test/java/com/mapzen/fragment/MapFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/MapFragmentTest.java
@@ -12,9 +12,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.oscim.core.GeoPoint;
 import org.oscim.event.Gesture;
-import org.oscim.layers.marker.ItemizedIconLayer;
+import org.oscim.layers.marker.ItemizedLayer;
 import org.oscim.layers.marker.MarkerItem;
 import org.oscim.map.TestMap;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowToast;
 
@@ -23,6 +24,7 @@ import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.util.FragmentTestUtil.startFragment;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class MapFragmentTest {
     private MapFragment mapFragment;
@@ -46,7 +48,7 @@ public class MapFragmentTest {
 
     @Test
     public void onItemSingleTapUp_shouldToastMarkerItemTitle() throws Exception {
-        ItemizedIconLayer<MarkerItem> poiLayer = mapFragment.getPoiLayer();
+        ItemizedLayer<MarkerItem> poiLayer = mapFragment.getPoiLayer();
         poiLayer.addItem(new MarkerItem("Title", "Description", new GeoPoint(0, 0)));
         poiLayer.onGesture(Gesture.TAP, new FakeMotionEvent(0, 0));
         Assertions.assertThat(ShadowToast.getTextOfLatestToast()).isEqualTo("Title");
@@ -55,7 +57,7 @@ public class MapFragmentTest {
 
     @Test
     public void onItemSingleTapUp_shouldNotifyListener() throws Exception {
-        ItemizedIconLayer<MarkerItem> poiLayer = mapFragment.getPoiLayer();
+        ItemizedLayer<MarkerItem> poiLayer = mapFragment.getPoiLayer();
         poiLayer.addItem(new MarkerItem("Title", "Description", new GeoPoint(0, 0)));
         poiLayer.onGesture(Gesture.TAP, new FakeMotionEvent(0, 0));
         assertThat(listener.getIndex()).isEqualTo(0);
@@ -83,7 +85,7 @@ public class MapFragmentTest {
 
     @Test
     public void onPause_shouldEmptyMeMarkers() throws Exception {
-        ItemizedIconLayer<MarkerItem> meMarkerLayer = mapFragment.getMeMarkerLayer();
+        ItemizedLayer<MarkerItem> meMarkerLayer = mapFragment.getMeMarkerLayer();
         meMarkerLayer.addItem(new MarkerItem("Title", "Description", new GeoPoint(0, 0)));
         mapFragment.onPause();
         assertThat(meMarkerLayer.size()).isEqualTo(0);

--- a/app/src/test/java/com/mapzen/fragment/PagerResultsFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/PagerResultsFragmentTest.java
@@ -17,6 +17,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowToast;
 import org.robolectric.tester.android.view.TestMenu;
 import org.robolectric.util.FragmentTestUtil;
@@ -30,6 +31,7 @@ import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.application;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class PagerResultsFragmentTest {
     private PagerResultsFragment fragment;

--- a/app/src/test/java/com/mapzen/fragment/RouteFragmentTest.java
+++ b/app/src/test/java/com/mapzen/fragment/RouteFragmentTest.java
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.mapzen.widget.DistanceView;
 import com.mapzen.R;
 import com.mapzen.activity.BaseActivity;
 import com.mapzen.entity.Feature;
@@ -17,6 +16,7 @@ import com.mapzen.geo.DistanceFormatter;
 import com.mapzen.osrm.Instruction;
 import com.mapzen.shadows.ShadowVolley;
 import com.mapzen.support.MapzenTestRunner;
+import com.mapzen.widget.DistanceView;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.util.FragmentTestUtil;
@@ -40,6 +41,7 @@ import static com.mapzen.support.TestHelper.initMapFragment;
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class RouteFragmentTest {
 

--- a/app/src/test/java/com/mapzen/shadows/ShadowMapView.java
+++ b/app/src/test/java/com/mapzen/shadows/ShadowMapView.java
@@ -8,6 +8,9 @@ import org.oscim.android.MapView;
 import org.oscim.android.canvas.AndroidGraphics;
 import org.oscim.backend.AssetAdapter;
 import org.oscim.backend.CanvasAdapter;
+import org.oscim.map.Map;
+import org.oscim.map.TestMap;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowView;
 
@@ -20,5 +23,10 @@ public class ShadowMapView extends ShadowView {
     public void __constructor__(Context context, AttributeSet attributeSet) {
         CanvasAdapter.g = AndroidGraphics.INSTANCE;
         AssetAdapter.g = new AndroidAssetAdapter(context);
+    }
+
+    @Implementation
+    public Map getMap() {
+        return new TestMap();
     }
 }

--- a/app/src/test/java/com/mapzen/support/TestHelper.java
+++ b/app/src/test/java/com/mapzen/support/TestHelper.java
@@ -8,6 +8,7 @@ import com.mapzen.entity.Feature;
 import com.mapzen.fragment.MapFragment;
 
 import org.apache.commons.io.FileUtils;
+import org.oscim.android.MapView;
 import org.oscim.map.TestMap;
 import org.robolectric.tester.android.view.TestMenu;
 
@@ -30,7 +31,7 @@ public final class TestHelper {
     public static TestBaseActivity initBaseActivity(TestMenu menu) {
         TestBaseActivity activity = buildActivity(TestBaseActivity.class).create().visible().get();
         activity.onCreateOptionsMenu(menu);
-        activity.registerMapView(new TestMap());
+        activity.registerMapView(new MapView(activity));
         return activity;
     }
 

--- a/app/src/test/java/com/mapzen/util/ApiHelperTest.java
+++ b/app/src/test/java/com/mapzen/util/ApiHelperTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.oscim.core.BoundingBox;
 import org.oscim.core.GeoPoint;
+import org.robolectric.annotation.Config;
 
 import static com.mapzen.util.ApiHelper.getRouteUrlForCar;
 import static com.mapzen.util.ApiHelper.getRouteUrlForFoot;
@@ -13,6 +14,7 @@ import static com.mapzen.util.ApiHelper.getUrlForSearch;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class ApiHelperTest {
     @Test

--- a/app/src/test/java/com/mapzen/util/DisplayHelperTest.java
+++ b/app/src/test/java/com/mapzen/util/DisplayHelperTest.java
@@ -7,11 +7,13 @@ import com.mapzen.support.MapzenTestRunner;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 
 import static com.mapzen.util.DisplayHelper.IconStyle;
 import static com.mapzen.util.DisplayHelper.getRouteDrawable;
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class DisplayHelperTest {
     @Test

--- a/app/src/test/java/com/mapzen/widget/DistanceViewTest.java
+++ b/app/src/test/java/com/mapzen/widget/DistanceViewTest.java
@@ -7,9 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@Config(emulateSdk = 18)
 @RunWith(MapzenTestRunner.class)
 public class DistanceViewTest {
     private DistanceView view;

--- a/app/src/test/java/org/oscim/map/TestMap.java
+++ b/app/src/test/java/org/oscim/map/TestMap.java
@@ -30,7 +30,7 @@ public class TestMap extends Map {
     }
 
     @Override
-    public Viewport getViewport() {
+    public Viewport viewport() {
         return new Viewport(this);
     }
 }


### PR DESCRIPTION
- Renames ItemizedIconLayer -> ItemizedLayer in MapFragmentTest.
- Returns a new TestMap via getMap() in ShadowMapView.
- Registers TestMap via MapView in TestHelper.initBaseActivity().
- Renames getViewport() -> viewport() in TestMap.
- Adds @Config(emulateSdk = 18) to all test classes (Robolectric does not yet support API 19).
- Fixes checkstyle errors in Feature and MapFragment.
