### PR TITLE
Single search result view (autocomplete results)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     compile 'org.oscim:vtm:0.5.9-SNAPSHOT'
     compile 'org.oscim:vtm-android:0.5.9-SNAPSHOT@aar'
     compile 'com.google.android.gms:play-services:4.0.30'
+    compile 'com.jakewharton:butterknife:4.0.1'
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(':geojson')
     compile project(':volley')

--- a/app/cq-configs/checkstyle/checkstyle.xml
+++ b/app/cq-configs/checkstyle/checkstyle.xml
@@ -164,6 +164,7 @@
         <module name="InterfaceIsType"/>
         <module name="VisibilityModifier">
           <property name="protectedAllowed" value="true" />
+          <property name="packageAllowed" value="true" />
 	</module>
 
 

--- a/app/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/app/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -21,12 +21,12 @@ import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
 import com.mapzen.MapzenApplication;
 import com.mapzen.R;
-import com.mapzen.adapters.AutoCompleteAdapter;
 import com.mapzen.entity.Feature;
 import com.mapzen.fragment.ListResultsFragment;
 import com.mapzen.fragment.MapFragment;
-import com.mapzen.fragment.PagerResultsFragment;
+import com.mapzen.search.AutoCompleteAdapter;
 import com.mapzen.search.OnPoiClickListener;
+import com.mapzen.search.PagerResultsFragment;
 import com.mapzen.util.Logger;
 import com.mapzen.util.MapzenProgressDialogFragment;
 
@@ -46,8 +46,6 @@ public class BaseActivity extends MapActivity {
     private MenuItem menuItem;
     private MapzenApplication app;
     private MapFragment mapFragment;
-    public static final String SEARCH_RESULTS_STACK = "search_results_stack";
-    public static final String ROUTE_STACK = "route_stack";
     private MapzenProgressDialogFragment progressDialogFragment;
     private LocationClient locationClient;
     private LocationListener locationListener = new LocationListener() {
@@ -263,7 +261,7 @@ public class BaseActivity extends MapActivity {
     private void setupAdapter(SearchView searchView) {
         if (autoCompleteAdapter == null) {
             autoCompleteAdapter = new AutoCompleteAdapter(getActionBar().getThemedContext(),
-                    this, app.getColumns());
+                    this, app.getColumns(), getSupportFragmentManager());
             autoCompleteAdapter.setSearchView(searchView);
             autoCompleteAdapter.setMapFragment(mapFragment);
         }

--- a/app/src/main/java/com/mapzen/fragment/ListResultsFragment.java
+++ b/app/src/main/java/com/mapzen/fragment/ListResultsFragment.java
@@ -14,6 +14,7 @@ import com.mapzen.R;
 import com.mapzen.activity.BaseActivity;
 import com.mapzen.adapters.PlaceArrayAdapter;
 import com.mapzen.entity.Feature;
+import com.mapzen.search.PagerResultsFragment;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/com/mapzen/fragment/RouteFragment.java
+++ b/app/src/main/java/com/mapzen/fragment/RouteFragment.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mapzen.activity.BaseActivity.COM_MAPZEN_UPDATES_LOCATION;
-import static com.mapzen.activity.BaseActivity.ROUTE_STACK;
 import static com.mapzen.entity.Feature.NAME;
 
 public class RouteFragment extends BaseFragment implements DirectionListFragment.DirectionListener,
@@ -232,7 +231,7 @@ public class RouteFragment extends BaseFragment implements DirectionListFragment
 
     private void displayRoute() {
         act.getSupportFragmentManager().beginTransaction()
-                .addToBackStack(ROUTE_STACK)
+                .addToBackStack(null)
                 .add(R.id.routes_container, this, RouteFragment.TAG)
                 .commit();
     }

--- a/app/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
+++ b/app/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
@@ -1,8 +1,9 @@
-package com.mapzen.adapters;
+package com.mapzen.search;
 
 import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
+import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -16,6 +17,7 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.mapzen.MapzenApplication;
+import com.mapzen.R;
 import com.mapzen.activity.BaseActivity;
 import com.mapzen.entity.Feature;
 import com.mapzen.fragment.MapFragment;
@@ -36,11 +38,14 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
     private MapFragment mapFragment;
     private BaseActivity act;
     private MapzenApplication app;
+    private FragmentManager fragmentManager;
 
-    public AutoCompleteAdapter(Context context, BaseActivity act, String[] columns) {
+    public AutoCompleteAdapter(Context context, BaseActivity act, String[] columns,
+            FragmentManager fragmentManager) {
         super(context, new MatrixCursor(columns), 0);
         this.act = act;
         this.app = (MapzenApplication) act.getApplication();
+        this.fragmentManager = fragmentManager;
     }
 
     public void setSearchView(SearchView view) {
@@ -68,6 +73,13 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
                 mapFragment.clearMarkers();
                 mapFragment.updateMap();
                 mapFragment.centerOn(feature);
+                PagerResultsFragment pagerResultsFragment = PagerResultsFragment.newInstance(act);
+                fragmentManager.beginTransaction()
+                        .replace(R.id.pager_results_container, pagerResultsFragment,
+                                PagerResultsFragment.TAG).commit();
+                fragmentManager.executePendingTransactions();
+                pagerResultsFragment.add(feature);
+                pagerResultsFragment.displayResults(1, 0);
             }
         });
         parent.setOnTouchListener(new View.OnTouchListener() {
@@ -162,4 +174,3 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
         };
     }
 }
-

--- a/app/src/main/res/layout/dummy.xml
+++ b/app/src/main/res/layout/dummy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/pager_results_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:background="@android:color/white" />
+
+    <FrameLayout
+        android:id="@+id/routes_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <FrameLayout
+        android:id="@+id/full_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_search_results.xml
+++ b/app/src/main/res/layout/fragment_search_results.xml
@@ -3,9 +3,11 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="120dp"
+    android:layout_height="wrap_content"
     android:id="@+id/results_wrapper">
+
     <RelativeLayout
+        android:id="@+id/multi_result_header"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:paddingTop="8dp"
@@ -33,7 +35,7 @@
 
     <android.support.v4.view.ViewPager
         android:id="@+id/results"
-        android:layout_height="wrap_content"
-        android:layout_width="fill_parent"
+        android:layout_height="75dp"
+        android:layout_width="match_parent"
         android:layout_gravity="bottom" />
 </LinearLayout>

--- a/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/app/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -9,7 +9,7 @@ import android.widget.SearchView;
 import com.mapzen.MapzenApplication;
 import com.mapzen.R;
 import com.mapzen.fragment.ListResultsFragment;
-import com.mapzen.fragment.PagerResultsFragment;
+import com.mapzen.search.PagerResultsFragment;
 import com.mapzen.shadows.ShadowLocationClient;
 import com.mapzen.shadows.ShadowVolley;
 import com.mapzen.support.MapzenTestRunner;

--- a/app/src/test/java/com/mapzen/search/AutoCompleteAdapterTest.java
+++ b/app/src/test/java/com/mapzen/search/AutoCompleteAdapterTest.java
@@ -1,0 +1,92 @@
+package com.mapzen.search;
+
+import android.support.v4.app.FragmentManager;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.SearchView;
+
+import com.mapzen.MapzenApplication;
+import com.mapzen.R;
+import com.mapzen.activity.BaseActivity;
+import com.mapzen.adapters.SearchViewAdapter;
+import com.mapzen.entity.Feature;
+import com.mapzen.fragment.ItemFragment;
+import com.mapzen.support.DummyActivity;
+import com.mapzen.support.MapzenTestRunner;
+import com.mapzen.support.TestHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.tester.android.database.TestCursor;
+import org.robolectric.util.ActivityController;
+
+import static com.mapzen.support.TestHelper.getTestFeature;
+import static com.mapzen.support.TestHelper.initMapFragment;
+import static org.fest.assertions.api.ANDROID.assertThat;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.robolectric.Robolectric.application;
+import static org.robolectric.Robolectric.buildActivity;
+
+@Config(emulateSdk = 18)
+@RunWith(MapzenTestRunner.class)
+public class AutoCompleteAdapterTest {
+    private AutoCompleteAdapter adapter;
+    private BaseActivity baseActivity;
+    private View view;
+    private FragmentManager fragmentManager;
+    private Feature feature;
+
+    @Before
+    public void setUp() throws Exception {
+        ActivityController<DummyActivity> controller = buildActivity(DummyActivity.class);
+        controller.create().start().resume();
+        fragmentManager = controller.get().getSupportFragmentManager();
+        baseActivity = TestHelper.initBaseActivity();
+        adapter = new AutoCompleteAdapter(baseActivity.getActionBar().getThemedContext(),
+                baseActivity, ((MapzenApplication) application).getColumns(), fragmentManager);
+        adapter.setSearchView(new SearchView(application));
+        adapter.setMapFragment(initMapFragment(baseActivity));
+        view = adapter.newView(baseActivity, new TestCursor(), new FrameLayout(baseActivity));
+        feature = getTestFeature();
+        view.setTag(feature);
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertThat(adapter).isNotNull();
+    }
+
+    @Test
+    public void onClick_shouldCreatePagerResultsFragment() throws Exception {
+        view.performClick();
+        assertThat(fragmentManager).hasFragmentWithTag(PagerResultsFragment.TAG);
+    }
+
+    @Test
+    public void onClick_shouldReplaceExistingPagerResultsFragment() throws Exception {
+        PagerResultsFragment fragment1 = PagerResultsFragment.newInstance(baseActivity);
+        fragmentManager.beginTransaction().add(R.id.pager_results_container, fragment1,
+                PagerResultsFragment.TAG).commit();
+
+        view.performClick();
+        PagerResultsFragment fragment2 = (PagerResultsFragment) fragmentManager
+                .findFragmentByTag(PagerResultsFragment.TAG);
+
+        assertThat(fragment1).isNotAdded();
+        assertThat(fragment2).isAdded();
+        assertThat(fragment1).isNotSameAs(fragment2);
+    }
+
+    @Test
+    public void onClick_shouldAddFeatureToPagerResultsFragment() throws Exception {
+        view.performClick();
+        PagerResultsFragment pagerResultsFragment = (PagerResultsFragment)
+                fragmentManager.findFragmentByTag(PagerResultsFragment.TAG);
+        SearchViewAdapter searchViewAdapter = (SearchViewAdapter)
+                pagerResultsFragment.pager.getAdapter();
+        ItemFragment itemFragment = (ItemFragment) searchViewAdapter.getItem(0);
+        assertThat(itemFragment.getFeature()).isSameAs(feature);
+    }
+}

--- a/app/src/test/java/com/mapzen/search/PagerResultsFragmentTest.java
+++ b/app/src/test/java/com/mapzen/search/PagerResultsFragmentTest.java
@@ -1,6 +1,5 @@
-package com.mapzen.fragment;
+package com.mapzen.search;
 
-import android.widget.Button;
 import android.widget.SearchView;
 import android.widget.Toast;
 
@@ -9,6 +8,7 @@ import com.mapzen.MapzenApplication;
 import com.mapzen.R;
 import com.mapzen.activity.BaseActivity;
 import com.mapzen.entity.Feature;
+import com.mapzen.fragment.ListResultsFragment;
 import com.mapzen.shadows.ShadowVolley;
 import com.mapzen.support.MapzenTestRunner;
 import com.mapzen.util.MapzenProgressDialogFragment;
@@ -56,6 +56,21 @@ public class PagerResultsFragmentTest {
     }
 
     @Test
+    public void shouldInjectViewPager() throws Exception {
+        assertThat(fragment.pager).isNotNull();
+    }
+
+    @Test
+    public void shouldInjectPaginationIndicator() throws Exception {
+        assertThat(fragment.indicator).isNotNull();
+    }
+
+    @Test
+    public void shouldInjectViewAllButton() throws Exception {
+        assertThat(fragment.viewAll).isNotNull();
+    }
+
+    @Test
     public void executeSearchOnMap_shouldCancelOutstandingAutoCompleteRequests() throws Exception {
         app.enqueueApiRequest(Feature.suggest("Empire", null, null));
         app.enqueueApiRequest(Feature.suggest("Empire State", null, null));
@@ -94,9 +109,23 @@ public class PagerResultsFragmentTest {
 
     @Test
     public void viewAll_shouldAddListResultsFragment() throws Exception {
-        Button viewAllButton = (Button) fragment.getView().findViewById(R.id.view_all);
-        viewAllButton.performClick();
+        fragment.viewAll.performClick();
         assertThat(act.getSupportFragmentManager()).hasFragmentWithTag(ListResultsFragment.TAG);
+    }
+
+    @Test
+    public void displayResults_shouldShowMultiResultHeaderForMultipleResults() throws Exception {
+        fragment.add(new Feature());
+        fragment.add(new Feature());
+        fragment.displayResults(2, 0);
+        assertThat(fragment.multiResultHeader).isVisible();
+    }
+
+    @Test
+    public void displayResults_shouldHideMultiResultHeaderForSingleResult() throws Exception {
+        fragment.add(new Feature());
+        fragment.displayResults(1, 0);
+        assertThat(fragment.multiResultHeader).isGone();
     }
 
     private void assertRequest(Request request) {

--- a/app/src/test/java/com/mapzen/support/DummyActivity.java
+++ b/app/src/test/java/com/mapzen/support/DummyActivity.java
@@ -1,0 +1,14 @@
+package com.mapzen.support;
+
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+
+import com.mapzen.R;
+
+public class DummyActivity extends FragmentActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.dummy);
+    }
+}

--- a/app/src/test/java/com/mapzen/support/TestHelper.java
+++ b/app/src/test/java/com/mapzen/support/TestHelper.java
@@ -29,6 +29,7 @@ public final class TestHelper {
     }
 
     public static TestBaseActivity initBaseActivity(TestMenu menu) {
+        // TODO: Add start() and resume() to TestBaseActivity initialization.
         TestBaseActivity activity = buildActivity(TestBaseActivity.class).create().visible().get();
         activity.onCreateOptionsMenu(menu);
         activity.registerMapView(new MapView(activity));

--- a/lint.xml
+++ b/lint.xml
@@ -8,5 +8,6 @@
     <issue id="TypographyDashes" severity="ignore">
 	<ignore path="app/src/main/res/values/com_crashlytics_export_strings.xml" />
     </issue>
+    <issue id="InvalidPackage" severity="ignore" />
 </lint>
 


### PR DESCRIPTION
- Displays pager results fragment when auto complete item is clicked.
- Replaces existing PagerResultsFragment with new instance created by AutoCompleteAdapter.
- Moves AutoCompleteAdapter and PagerResultsFragment into package com.mapzen.search.
- Displays feature data for a single search result via autocomplete.
- Hides pagination and view all link for single search result view.

Additionally, this change set introduces ButterKnife for view injection.
- Injects views in PagerResultsFragment.
- Reduces boilerplate code for views.
- Improves testability.
- Updates checkstyle and lint to play nice with ButterKnife annotations.
