### PR TITLE
Fixes Crashlytics for Maven/IntelliJ builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,22 @@
     <name>Mapzen</name>
 
     <repositories>
+
         <repository>
             <id>crashlytics-repo</id>
             <url>http://download.crashlytics.com/maven</url>
         </repository>
+
     </repositories>
+
+    <pluginRepositories>
+
+        <pluginRepository>
+            <id>crashlytics-plugin-repo</id>
+            <url>http://download.crashlytics.com/maven</url>
+        </pluginRepository>
+
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -132,7 +143,7 @@
         <dependency>
             <groupId>com.crashlytics.android</groupId>
             <artifactId>crashlytics</artifactId>
-            <version>[1.0.2,)</version>
+            <version>[1.1.10,)</version>
         </dependency>
     </dependencies>
 
@@ -158,6 +169,26 @@
                         <platform>19</platform>
                     </sdk>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.crashlytics</groupId>
+                <artifactId>crashlytics-maven</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>GenerateResources</id>
+                        <goals>
+                            <goal>GenerateResources</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>CleanupResources</id>
+                        <goals>
+                            <goal>CleanupResources</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- TODO: checkstyle plugin-->


### PR DESCRIPTION
- Updates crashlytics dependency to version [1.1.10,)
- Adds crashlytics-maven plugin

Building the app in IntelliJ IDEA requires installing the Craslytics plugin available here:

https://crashlytics.com/downloads/intellij
