### PR TITLE
Fixes walking radius cast.

### DIFF
--- a/src/main/java/com/mapzen/fragment/RouteFragment.java
+++ b/src/main/java/com/mapzen/fragment/RouteFragment.java
@@ -119,9 +119,11 @@ public class RouteFragment extends BaseFragment implements DirectionListFragment
     }
 
     public int getWalkingAdvanceRadius() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(act);
-        return prefs.getInt(act.getString(R.string.settings_key_walking_advance_radius),
-                WALKING_ADVANCE_DEFAULT_RADIUS);
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(act);
+        final String walkingAdvanceString =
+                prefs.getString(act.getString(R.string.settings_key_walking_advance_radius),
+                        Integer.toString(WALKING_ADVANCE_DEFAULT_RADIUS));
+        return Integer.valueOf(walkingAdvanceString);
     }
 
     public void setInstructions(ArrayList<Instruction> instructions) {

--- a/src/test/java/com/mapzen/fragment/RouteFragmentTest.java
+++ b/src/test/java/com/mapzen/fragment/RouteFragmentTest.java
@@ -541,8 +541,8 @@ public class RouteFragmentTest {
     private void setWalkingRadius(int expected) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(act);
         SharedPreferences.Editor prefEditor = prefs.edit();
-        prefEditor.putInt(act.getString(R.string.settings_key_walking_advance_radius), expected);
+        prefEditor.putString(act.getString(R.string.settings_key_walking_advance_radius),
+                Integer.toString(expected));
         prefEditor.commit();
     }
-
 }


### PR DESCRIPTION
This was still crashing for me (never set a radius in settings).

If PreferenceManager wants it to be a string, let's make it a string!
