### PR TITLE
Shows current location at default zoom level on launch.

### DIFF
--- a/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -91,10 +91,10 @@ public class BaseActivity extends MapActivity {
         app = (MapzenApplication) getApplication();
         setContentView(R.layout.base);
         initMapFragment();
-        initLocationClient();
         progressDialogFragment = new MapzenProgressDialogFragment();
         dbHelper = new LocationDatabaseHelper(this);
         initMapController();
+        initLocationClient();
     }
 
     @Override
@@ -157,6 +157,8 @@ public class BaseActivity extends MapActivity {
         public void onConnected(Bundle bundle) {
             Location location = locationClient.getLastLocation();
             getMapController().setLocation(location);
+            getMapController().setZoomLevel(MapController.DEFAULT_ZOOMLEVEL);
+            mapFragment.findMe();
             Logger.d("Location: last location: " + location.toString());
             LocationRequest locationRequest = LocationRequest.create();
             locationRequest.setInterval(LOCATION_INTERVAL);

--- a/src/test/java/org/oscim/map/TestMap.java
+++ b/src/test/java/org/oscim/map/TestMap.java
@@ -1,10 +1,7 @@
 package org.oscim.map;
 
-import org.oscim.core.MapPosition;
-
 public class TestMap extends Map {
     private TestViewport viewport;
-    private MapPosition mapPosition;
 
     public TestMap() {
         super();
@@ -37,17 +34,6 @@ public class TestMap extends Map {
     @Override
     public int getHeight() {
         return 0;
-    }
-
-    @Override
-    public void setMapPosition(double latitude, double longitude, double scale) {
-        super.setMapPosition(latitude, longitude, scale);
-        mapPosition = new MapPosition(latitude, longitude, scale);
-    }
-
-    @Override
-    public MapPosition getMapPosition() {
-        return mapPosition;
     }
 
     @Override


### PR DESCRIPTION
- Sets default zoom level and finds user location when location services connects.
- Moves initLocationClient() after initMapController() to prevent possible race condition.
- Simplifies TestMap by removing setMapPosition(...) and getMapPosition(). Tests still pass yay!
