### PR TITLE
letting hardware volume control control media while in app

### DIFF
--- a/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabase;
 import android.location.Location;
+import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceFragment;
@@ -98,6 +99,7 @@ public class BaseActivity extends MapActivity {
         initMapController();
         initLocationClient();
         initDebugView();
+        setVolumeControlStream(AudioManager.STREAM_MUSIC);
     }
 
     @Override

--- a/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
+import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -66,6 +67,11 @@ public class BaseActivityTest {
     @Test
     public void onCreate_shouldInitializeMapController() throws Exception {
         assertThat(MapController.getMapController().getMap()).isNotNull();
+    }
+
+    @Test
+    public void onCreate_shouldSetVolumeControlStream() throws Exception {
+        assertThat(activity.getVolumeControlStream()).isEqualTo(AudioManager.STREAM_MUSIC);
     }
 
     @Test


### PR DESCRIPTION
Explicitly set audio controls when the activity is created ... I think we need some more audio controls as well such as ducking etc. But _enter catchphrase here_ ...

https://trello.com/c/zPkMma4K/190-triple-check-audio-works 
