### PR TITLE
Adds maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,24 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
+    <scm>
+        <url>http://github.com/mapzen/android</url>
+        <connection>scm:git:git://github.com/mapzen/android.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/mapzen/android.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <url>http://10.0.1.88:8081//nexus/content/repositories/releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <url>http://10.0.1.88:8081//nexus/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -264,6 +282,12 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
Automates the following steps:
- Increment version and produce release build
- Commit changes and push to master branch on GitHub
- Create tag and push to GitHub
- Deploy to Sonatype Nexus

Usage

```
$ mvn release:prepare -DignoreSnapshots=true
$ mvn release:perform
```

**Requires Sonatype credentials to be added to local `.m2/settings.xml`.**

http://maven.apache.org/maven-release/maven-release-plugin/index.html
