### PR TITLE
Include Robolectric snapshot via Sonatype OSS repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ $ cd vtm-native-libs && ./install-dependencies.sh
 $ cd speakerbox && mvn clean install
 </pre></code>
 
-### Install Robolectric
-
-<pre><code>$ git clone https://github.com/mapzen/robolectric.git
-$ cd robolectric && mvn clean install
-</pre></code>
-
 ### Install Samsung Accessories
 
 <pre><code>


### PR DESCRIPTION
Local install no longer needed. Simply add (and activate) the following profile in settings.xml.

```
<settings>
    ...
    <activeProfiles>
        <activeProfile>snapshots</activeProfile>
        ...
    </activeProfiles>
    <profiles>
        <profile>
            <id>snapshots</id>
            <repositories>
                <repository>
                    <id>snapshots-repo</id>
                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                    <releases>
                        <enabled>false</enabled>
                    </releases>
                    <snapshots>
                        <enabled>true</enabled>
                    </snapshots>
                </repository>
            </repositories>
        </profile>
        ...
    </profiles>
    ...
</settings>
```
