### PR TITLE
Adds -noverify flag to maven surefire plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,15 @@
                     <version>3.8.2</version>
                     <extensions>true</extensions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                    <configuration>
+                        <argLine>-noverify</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Command line option `-DargLine="-noverify"` is no longer needed when building with Java 7.
