### PR TITLE
Introduces a easy way to update fragment views

### DIFF
--- a/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -11,7 +11,6 @@ import com.mapzen.core.OSMOauthFragment;
 import com.mapzen.core.SettingsFragment;
 import com.mapzen.fragment.ListResultsFragment;
 import com.mapzen.fragment.MapFragment;
-import com.mapzen.route.RoutePreviewFragment;
 import com.mapzen.search.AutoCompleteAdapter;
 import com.mapzen.search.OnPoiClickListener;
 import com.mapzen.search.PagerResultsFragment;
@@ -71,6 +70,7 @@ import static com.mapzen.search.SavedSearch.getSavedSearch;
 public class BaseActivity extends MapActivity {
     @Inject MapzenProgressDialogFragment progressDialogFragment;
     public static final int LOCATION_INTERVAL = 1000;
+    public static final String COM_MAPZEN_UPDATE_VIEW = "com.mapzen.updates.view";
     public static final String COM_MAPZEN_UPDATES_LOCATION = "com.mapzen.updates.location";
     public static final String
             DEBUG_DATA_ENDPOINT = "http://on-the-road.dev.mapzen.com/upload";
@@ -523,13 +523,12 @@ public class BaseActivity extends MapActivity {
         this.requestToken = requestToken;
     }
 
-    public void refreshRoutePreview() {
-        RoutePreviewFragment fragment =
-                (RoutePreviewFragment) getSupportFragmentManager().
-                        findFragmentByTag(RoutePreviewFragment.TAG);
-        if (fragment != null) {
-            fragment.createRouteToDestination();
-        }
+    public void updateView() {
+        sendBroadcast(new Intent(COM_MAPZEN_UPDATE_VIEW));
+    }
+
+    public interface ViewUpdater {
+        public void onViewUpdate();
     }
 
     private void initAlarm() {

--- a/src/main/java/com/mapzen/fragment/BaseFragment.java
+++ b/src/main/java/com/mapzen/fragment/BaseFragment.java
@@ -1,5 +1,9 @@
 package com.mapzen.fragment;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.widget.Toast;
@@ -9,7 +13,9 @@ import com.mapzen.activity.BaseActivity;
 
 import retrofit.RetrofitError;
 
-public abstract class BaseFragment extends Fragment {
+import static com.mapzen.activity.BaseActivity.COM_MAPZEN_UPDATE_VIEW;
+
+public abstract class BaseFragment extends Fragment implements BaseActivity.ViewUpdater {
     protected BaseActivity act;
     protected MapFragment mapFragment;
     protected MapzenApplication app;
@@ -63,5 +69,22 @@ public abstract class BaseFragment extends Fragment {
         Toast.makeText(act, act.getString(R.string.generic_server_error), Toast.LENGTH_LONG).show();
         act.dismissProgressDialog();
         Log.e(MapzenApplication.LOG_TAG, "request: error: " + error.toString());
+    }
+
+    protected void registerViewUpdater() {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(COM_MAPZEN_UPDATE_VIEW);
+        act.registerReceiver(new ViewUpdatesReceiver(), filter);
+    }
+
+    @Override
+    public void onViewUpdate() {
+    }
+
+    public class ViewUpdatesReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            onViewUpdate();
+        }
     }
 }

--- a/src/main/java/com/mapzen/route/RouteFragment.java
+++ b/src/main/java/com/mapzen/route/RouteFragment.java
@@ -252,7 +252,7 @@ public class RouteFragment extends BaseFragment implements DirectionListFragment
         super.onDetach();
         markReadyForUpload(routeId);
         clearRoute();
-        act.refreshRoutePreview();
+        act.updateView();
         mapFragment.showLocationMarker();
         mapFragment.getMap().layers().remove(routeLocationIndicator);
     }

--- a/src/main/java/com/mapzen/route/RoutePreviewFragment.java
+++ b/src/main/java/com/mapzen/route/RoutePreviewFragment.java
@@ -46,7 +46,8 @@ import static com.mapzen.osrm.Router.Type.BIKING;
 import static com.mapzen.osrm.Router.Type.DRIVING;
 import static com.mapzen.osrm.Router.Type.WALKING;
 
-public class RoutePreviewFragment extends BaseFragment implements Router.Callback {
+public class RoutePreviewFragment extends BaseFragment
+        implements Router.Callback {
     public static final String TAG = RoutePreviewFragment.class.getSimpleName();
     public static final int ROUTE_ZOOM_LEVEL = 19;
     private SimpleFeature destination;
@@ -101,6 +102,7 @@ public class RoutePreviewFragment extends BaseFragment implements Router.Callbac
         View view = inflater.inflate(R.layout.route_preview, container, false);
         ButterKnife.inject(this, view);
         setOriginAndDestination();
+        registerViewUpdater();
         return view;
     }
 
@@ -250,6 +252,11 @@ public class RoutePreviewFragment extends BaseFragment implements Router.Callbac
     public void failure(int statusCode) {
         path.clearPath();
         onServerError(statusCode);
+    }
+
+    @Override
+    public void onViewUpdate() {
+        createRouteToDestination();
     }
 
     private MarkerItem getMarkerItem(int icon, Location loc) {

--- a/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -517,6 +517,14 @@ public class BaseActivityTest {
                 .hasFragmentWithTag(OSMOauthFragment.TAG);
     }
 
+    @Test
+    public void updateView_shouldSendUpdateViewBroadcast() throws Exception {
+        activity.updateView();
+        List<Intent> intents = Robolectric.getShadowApplication().getBroadcastIntents();
+        assertThat(intents).hasSize(1);
+        assertThat(intents.get(0)).hasAction(BaseActivity.COM_MAPZEN_UPDATE_VIEW);
+    }
+
     private Location initLastLocation() {
         Location location = new Location(GPS_PROVIDER);
         location.setLatitude(1.0);

--- a/src/test/java/com/mapzen/route/RouteFragmentTest.java
+++ b/src/test/java/com/mapzen/route/RouteFragmentTest.java
@@ -363,7 +363,7 @@ public class RouteFragmentTest {
         fragment.setAct(baseActivityMock);
         FragmentTestUtil.startFragment(fragment);
         fragment.onDetach();
-        verify(baseActivityMock).refreshRoutePreview();
+        verify(baseActivityMock).updateView();
     }
 
     @Test

--- a/src/test/java/com/mapzen/route/RoutePreviewFragmentTest.java
+++ b/src/test/java/com/mapzen/route/RoutePreviewFragmentTest.java
@@ -23,8 +23,10 @@ import org.oscim.layers.marker.ItemizedLayer;
 import org.oscim.layers.marker.MarkerItem;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.FragmentTestUtil;
 
+import android.content.Intent;
 import android.location.Location;
 import android.widget.RadioButton;
 import android.widget.TextView;
@@ -36,6 +38,7 @@ import javax.inject.Inject;
 
 import static com.mapzen.MapController.getMapController;
 import static com.mapzen.MapController.locationToGeoPoint;
+import static com.mapzen.activity.BaseActivity.COM_MAPZEN_UPDATE_VIEW;
 import static com.mapzen.entity.SimpleFeature.NAME;
 import static com.mapzen.support.TestHelper.getFixture;
 import static com.mapzen.support.TestHelper.getTestLocation;
@@ -409,5 +412,17 @@ public class RoutePreviewFragmentTest {
         fragment.setMapFragment(mockMapFragment);
         fragment.onDetach();
         verify(mockMapFragment).updateMap();
+    }
+
+    @Test
+    public void onViewCreate_shouldSetViewUpdateReceiver() throws Exception {
+        ShadowApplication application = Robolectric.getShadowApplication();
+        assertThat(application.hasReceiverForIntent(new Intent(COM_MAPZEN_UPDATE_VIEW))).isTrue();
+    }
+
+    @Test
+    public void onUpdateView_shouldCreateRoute() throws Exception {
+        fragment.onViewUpdate();
+        Mockito.verify(router).fetch();
     }
 }


### PR DESCRIPTION
Implents update view in RoutePreviewFragment
- basically in any fragment
  call registerViewUpdater in onViewCreate
  then override onViewUpdate with the desired actions
