### PR TITLE
Preserves current search term in list result view even if user clears search box.

### DIFF
--- a/src/main/java/com/mapzen/search/ListResultsActivity.java
+++ b/src/main/java/com/mapzen/search/ListResultsActivity.java
@@ -1,8 +1,6 @@
 package com.mapzen.search;
 
-import com.mapzen.MapzenApplication;
 import com.mapzen.entity.SimpleFeature;
-import com.mapzen.fragment.ListResultsFragment;
 
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
@@ -12,6 +10,7 @@ import java.util.ArrayList;
 
 public class ListResultsActivity extends FragmentActivity {
     public static final String EXTRA_FEATURE_LIST = "com.mapzen.search.features";
+    public static final String EXTRA_SEARCH_TERM = "com.mapzen.search.term";
     public static final String EXTRA_INDEX = "com.mapzen.search.index";
 
     @Override
@@ -20,7 +19,7 @@ public class ListResultsActivity extends FragmentActivity {
         final ArrayList<SimpleFeature> simpleFeatures =
                 getIntent().getParcelableArrayListExtra(EXTRA_FEATURE_LIST);
         final ListResultsFragment fragment = ListResultsFragment.newInstance(simpleFeatures,
-                ((MapzenApplication) getApplication()).getCurrentSearchTerm());
+                getIntent().getStringExtra(EXTRA_SEARCH_TERM));
         getSupportFragmentManager().beginTransaction().add(android.R.id.content, fragment).commit();
         getActionBar().setDisplayHomeAsUpEnabled(true);
     }

--- a/src/main/java/com/mapzen/search/ListResultsFragment.java
+++ b/src/main/java/com/mapzen/search/ListResultsFragment.java
@@ -1,9 +1,8 @@
-package com.mapzen.fragment;
+package com.mapzen.search;
 
 import com.mapzen.R;
 import com.mapzen.adapters.PlaceArrayAdapter;
 import com.mapzen.entity.SimpleFeature;
-import com.mapzen.search.ListResultsActivity;
 
 import android.app.Activity;
 import android.content.Intent;

--- a/src/main/java/com/mapzen/search/PagerResultsFragment.java
+++ b/src/main/java/com/mapzen/search/PagerResultsFragment.java
@@ -62,6 +62,8 @@ public class PagerResultsFragment extends BaseFragment {
     @InjectView(R.id.results)
     ViewPager pager;
 
+    private String searchTermForCurrentResults;
+
     public static PagerResultsFragment newInstance(BaseActivity act) {
         PagerResultsFragment pagerResultsFragment = new PagerResultsFragment();
         pagerResultsFragment.setAct(act);
@@ -137,6 +139,7 @@ public class PagerResultsFragment extends BaseFragment {
     @OnClick(R.id.view_all) @SuppressWarnings("unused") public void onClickViewAll() {
         final Intent intent = new Intent(getActivity(), ListResultsActivity.class);
         intent.putExtra(ListResultsActivity.EXTRA_FEATURE_LIST, simpleFeatures);
+        intent.putExtra(ListResultsActivity.EXTRA_SEARCH_TERM, searchTermForCurrentResults);
         startActivityForResult(intent, 0);
     }
 
@@ -230,6 +233,7 @@ public class PagerResultsFragment extends BaseFragment {
     public boolean executeSearchOnMap(final SearchView view, String query) {
         act.showProgressDialog();
         app.setCurrentSearchTerm(query);
+        searchTermForCurrentResults = query;
         getSavedSearch().store(query);
         getPelias().search(query, ApiHelper.getViewBox(mapFragment.getMap()),
                 getSearchCallback(view));

--- a/src/test/java/com/mapzen/search/ListResultsActivityTest.java
+++ b/src/test/java/com/mapzen/search/ListResultsActivityTest.java
@@ -2,7 +2,6 @@ package com.mapzen.search;
 
 import com.mapzen.entity.SimpleFeature;
 import com.mapzen.support.MapzenTestRunner;
-import com.mapzen.support.TestHelper;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +14,7 @@ import android.content.Intent;
 
 import java.util.ArrayList;
 
+import static com.mapzen.support.TestHelper.getTestSimpleFeature;
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
@@ -24,13 +24,15 @@ import static org.robolectric.Robolectric.getShadowApplication;
 @RunWith(MapzenTestRunner.class)
 public class ListResultsActivityTest {
     private ListResultsActivity activity;
+    private ListResultsFragment fragment;
 
     @Before
     public void setUp() throws Exception {
         ArrayList<SimpleFeature> features = new ArrayList<SimpleFeature>();
-        features.add(TestHelper.getTestSimpleFeature());
+        features.add(getTestSimpleFeature());
         Intent intent = new Intent();
         intent.putParcelableArrayListExtra(ListResultsActivity.EXTRA_FEATURE_LIST, features);
+        intent.putExtra(ListResultsActivity.EXTRA_SEARCH_TERM, "term");
         activity = buildActivity(ListResultsActivity.class)
                 .withIntent(intent)
                 .create()
@@ -38,6 +40,7 @@ public class ListResultsActivityTest {
                 .resume()
                 .visible()
                 .get();
+        fragment = (ListResultsFragment) activity.getSupportFragmentManager().getFragments().get(0);
     }
 
     @Test
@@ -63,5 +66,16 @@ public class ListResultsActivityTest {
     public void shouldFinishActivityOnOptionsItemHomeSelected() throws Exception {
         activity.onOptionsItemSelected(new TestMenuItem(android.R.id.home));
         assertThat(activity).isFinishing();
+    }
+
+    @Test
+    public void shouldDisplayFeaturesFromIntentExtra() throws Exception {
+        assertThat(fragment.getListAdapter().getItem(0))
+                .isEqualsToByComparingFields(getTestSimpleFeature());
+    }
+
+    @Test
+    public void shouldDisplaySearchTermFromIntentExtra() throws Exception {
+        assertThat(fragment.termTextView).hasText("\"term\"");
     }
 }

--- a/src/test/java/com/mapzen/search/ListResultsFragmentTest.java
+++ b/src/test/java/com/mapzen/search/ListResultsFragmentTest.java
@@ -1,7 +1,6 @@
-package com.mapzen.fragment;
+package com.mapzen.search;
 
 import com.mapzen.entity.SimpleFeature;
-import com.mapzen.search.ListResultsActivity;
 import com.mapzen.support.MapzenTestRunner;
 
 import org.junit.Before;

--- a/src/test/java/com/mapzen/search/PagerResultsFragmentTest.java
+++ b/src/test/java/com/mapzen/search/PagerResultsFragmentTest.java
@@ -142,6 +142,18 @@ public class PagerResultsFragmentTest {
     }
 
     @Test
+    public void viewAll_shouldParcelSearchTermForCurrentResults() throws Exception {
+        fragment.executeSearchOnMap(new SearchView(app), "Some fantastic term");
+        ImageView closeButton = (ImageView) act.getSearchView().findViewById(act.getResources()
+                .getIdentifier("android:id/search_close_btn", null, null));
+        closeButton.performClick();
+        fragment.viewAll.performClick();
+        assertThat(getShadowApplication().getNextStartedActivity()
+                .getStringExtra(ListResultsActivity.EXTRA_SEARCH_TERM))
+                .isEqualTo("Some fantastic term");
+    }
+
+    @Test
     public void displayResults_shouldShowMultiResultHeaderForMultipleResults() throws Exception {
         fragment.add(new SimpleFeature());
         fragment.add(new SimpleFeature());


### PR DESCRIPTION
- Retains search term for current result set even if search text view is cleared or new text has been entered (but not submitted).
- Passes search term for current results from `PagerResultsFragment` to `ListResultsActivity` as an intent extra.
- Passes search term for current results from `ListResultsActivity` to `ListResultsFragment` as new instance parameter.
- Adds missing test for passing feature list from `ListResultsActivity` to `ListResultsFragment` as new instance parameter.
- Moves `ListResultsFragment` into `com.mapzen.search` package.
