### PR TITLE
Offline Unit Tests: DataUploadService

### DIFF
--- a/src/main/java/com/mapzen/core/AppModule.java
+++ b/src/main/java/com/mapzen/core/AppModule.java
@@ -28,7 +28,8 @@ import dagger.Provides;
                 BaseActivity.class,
                 ItemFragment.class,
                 RouteFragment.class,
-                RoutePreviewFragment.class
+                RoutePreviewFragment.class,
+                DataUploadService.class
         },
         complete = false,
         library = true
@@ -42,6 +43,10 @@ public class AppModule {
 
     @Provides @Singleton Router provideRouter() {
         return Router.getRouter();
+    }
+
+    @Provides OAuthRequestFactory provideOAuthRequestFactory() {
+        return new OAuthRequestFactory();
     }
 
     @Provides @Singleton

--- a/src/main/java/com/mapzen/core/OAuthRequestFactory.java
+++ b/src/main/java/com/mapzen/core/OAuthRequestFactory.java
@@ -1,0 +1,16 @@
+package com.mapzen.core;
+
+import org.scribe.model.OAuthRequest;
+
+import static org.scribe.model.Verb.GET;
+import static org.scribe.model.Verb.POST;
+
+public class OAuthRequestFactory {
+    public OAuthRequest getOAuthRequest() {
+        return new OAuthRequest(POST, OSMApi.BASE_URL + OSMApi.CREATE_GPX);
+    }
+
+    public OAuthRequest getPermissionsRequest() {
+        return new OAuthRequest(GET, OSMApi.BASE_URL + OSMApi.CHECK_PERMISSIONS);
+    }
+}

--- a/src/test/java/com/mapzen/core/DataUploadServiceTest.java
+++ b/src/test/java/com/mapzen/core/DataUploadServiceTest.java
@@ -12,15 +12,18 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.scribe.model.OAuthRequest;
-import org.scribe.model.Response;
 import org.scribe.model.Token;
 import org.scribe.oauth.OAuthService;
-
-import android.content.ContentValues;
-import android.database.Cursor;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -30,27 +33,22 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.StringWriter;
 
 import static com.mapzen.support.TestHelper.getTestInstruction;
 import static com.mapzen.support.TestHelper.getTestLocation;
+import static com.mapzen.util.DatabaseHelper.COLUMN_MSG;
 import static com.mapzen.util.DatabaseHelper.COLUMN_RAW;
 import static com.mapzen.util.DatabaseHelper.COLUMN_READY_FOR_UPLOAD;
 import static com.mapzen.util.DatabaseHelper.COLUMN_TABLE_ID;
 import static com.mapzen.util.DatabaseHelper.COLUMN_UPLOADED;
-import static com.mapzen.util.DatabaseHelper.TABLE_ROUTES;
-import static com.mapzen.util.DatabaseHelper.COLUMN_MSG;
 import static com.mapzen.util.DatabaseHelper.TABLE_LOCATIONS;
+import static com.mapzen.util.DatabaseHelper.TABLE_ROUTES;
 import static com.mapzen.util.DatabaseHelper.valuesForLocationCorrection;
-
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -102,8 +100,7 @@ public class DataUploadServiceTest {
     public void onStartCommand_shouldNotMarkUploaded() throws Exception {
         String expectedRouteId = "route-1";
         makeRouteReady(expectedRouteId);
-        DataUploadService spy = spy(service);
-        spy.onStartCommand(null, 0, 0);
+        service.onStartCommand(null, 0, 0);
         Cursor cursor = app.getDb().query(TABLE_ROUTES, new String[] {COLUMN_UPLOADED},
                 COLUMN_TABLE_ID + " = ? AND " + COLUMN_UPLOADED + " = 1",
                 new String[] {expectedRouteId}, null, null, null);
@@ -118,13 +115,7 @@ public class DataUploadServiceTest {
         String expectedRouteId = "route-1";
         makeRouteReady(expectedRouteId);
         app.setAccessToken(token);
-        DataUploadService spy = spy(service);
-        OAuthRequest mockRequest = mock(OAuthRequest.class);
-        doReturn(mockRequest).when(spy).getOAuthRequest();
-        Response responseMock = mock(Response.class);
-        doReturn(responseMock).when(mockRequest).send();
-        doReturn(true).when(responseMock).isSuccessful();
-        spy.onStartCommand(null, 0, 0);
+        service.onStartCommand(null, 0, 0);
         Cursor cursor = app.getDb().query(TABLE_ROUTES, new String[] {COLUMN_UPLOADED},
                 COLUMN_TABLE_ID + " = ? AND " + COLUMN_UPLOADED + " = 1",
                 new String[] {expectedRouteId}, null, null, null);

--- a/src/test/java/com/mapzen/core/TestAppModule.java
+++ b/src/test/java/com/mapzen/core/TestAppModule.java
@@ -34,7 +34,8 @@ import static org.mockito.Mockito.doNothing;
                 ItemFragmentTest.class,
                 MapFragment.class,
                 RoutePreviewFragment.class,
-                RoutePreviewFragmentTest.class
+                RoutePreviewFragmentTest.class,
+                DataUploadService.class
         },
         complete = false
 )
@@ -49,6 +50,10 @@ public class TestAppModule {
         Router router = Mockito.spy(getRouter());
         doNothing().when(router).fetch();
         return router;
+    }
+
+    @Provides OAuthRequestFactory provideOAuthRequestFactory() {
+        return new TestOAuthRequestFactory();
     }
 
     @Provides @Singleton PathLayer providePathLayer() {

--- a/src/test/java/com/mapzen/core/TestOAuthRequestFactory.java
+++ b/src/test/java/com/mapzen/core/TestOAuthRequestFactory.java
@@ -1,0 +1,28 @@
+package com.mapzen.core;
+
+import org.mockito.Mockito;
+import org.scribe.model.OAuthRequest;
+import org.scribe.model.Response;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class TestOAuthRequestFactory extends OAuthRequestFactory {
+    @Override
+    public OAuthRequest getOAuthRequest() {
+        OAuthRequest mockRequest = Mockito.spy(super.getOAuthRequest());
+        Response responseMock = mock(Response.class);
+        doReturn(responseMock).when(mockRequest).send();
+        doReturn(true).when(responseMock).isSuccessful();
+        return mockRequest;
+    }
+
+    @Override
+    public OAuthRequest getPermissionsRequest() {
+        OAuthRequest mockRequest = Mockito.spy(super.getPermissionsRequest());
+        Response responseMock = mock(Response.class);
+        doReturn(responseMock).when(mockRequest).send();
+        doReturn(true).when(responseMock).isSuccessful();
+        return mockRequest;
+    }
+}


### PR DESCRIPTION
- Creates and injects `OAuthRequestFactory` for generating requests.
- Injects `TestOAuthRequestFactory` in unit test environment to generate mock requests.
- Fixes test `shouldGenerateGPX_shouldSubmit()` (previously failing) for offline execution.
- Prevents actual requests from being sent over the network while running tests.
- Prevents `UnknownHostException`s from being thrown by background threads.
