### PR TITLE
search view text is cleared  after on back.

### DIFF
--- a/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -255,6 +255,7 @@ public class BaseActivity extends MapActivity {
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
+                resetSearchView();
                 final PagerResultsFragment pagerResultsFragment = getPagerResultsFragment();
                 if (pagerResultsFragment != null && pagerResultsFragment.isAdded()) {
                     getSupportFragmentManager().beginTransaction().remove(pagerResultsFragment)
@@ -289,6 +290,16 @@ public class BaseActivity extends MapActivity {
         toggleOSMLogin();
 
         return true;
+    }
+
+    private void resetSearchView() {
+        final SearchView searchView = (SearchView) searchMenuItem.getActionView();
+        searchView.setQuery("", false);
+        searchView.clearFocus();
+        searchView.setIconified(true);
+        app.setCurrentSearchTerm("");
+        autoCompleteAdapter.resetCursor();
+        autoCompleteAdapter.loadSavedSearches();
     }
 
     /**

--- a/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
+++ b/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
@@ -198,6 +198,9 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
         };
     }
 
+    public void resetCursor() {
+        swapCursor(new MatrixCursor(app.getColumns()));
+    }
     public void loadSavedSearches() {
         changeCursor(getSavedSearch().getCursor());
     }


### PR DESCRIPTION
- Resets search so that after closing the search menu item, the search term disappears and is replaced by most recent searches. 
