### PR TITLE
reset zoom level and points north on find me

### DIFF
--- a/src/main/java/com/mapzen/MapController.java
+++ b/src/main/java/com/mapzen/MapController.java
@@ -23,13 +23,13 @@ public final class MapController {
     public static final String KEY_MAP_SCALE = "scale";
     public static final String KEY_BEARING = "rotation";
 
-    public static final int DEFAULT_ZOOMLEVEL = 15;
+    public static final int DEFAULT_ZOOM_LEVEL = 15;
     public static final int ROUTE_ZOOM_LEVEL = 17;
     public static final String DEBUG_LOCATION = "fixed_debug_location";
     private static MapController mapController;
     private Map map;
     private Location location;
-    private MapPosition mapPosition = new MapPosition(1.0, 1.0, Math.pow(2, DEFAULT_ZOOMLEVEL));
+    private MapPosition mapPosition = new MapPosition(1.0, 1.0, Math.pow(2, DEFAULT_ZOOM_LEVEL));
     private BaseActivity activity;
     private SharedPreferences preferences;
 
@@ -125,7 +125,7 @@ public final class MapController {
     }
 
     public void resetZoomAndPointNorth() {
-        setZoomLevel(DEFAULT_ZOOMLEVEL);
+        setZoomLevel(DEFAULT_ZOOM_LEVEL);
         mapPosition.setBearing(0.0f);
     }
 
@@ -178,7 +178,7 @@ public final class MapController {
         int latitudeE6 = preferences.getInt(KEY_LATITUDE, 0);
         int longitudeE6 = preferences.getInt(KEY_LONGITUDE, 0);
         float scale = preferences.getFloat(KEY_MAP_SCALE,
-                (float) Math.pow(2, DEFAULT_ZOOMLEVEL));
+                (float) Math.pow(2, DEFAULT_ZOOM_LEVEL));
         float tilt = preferences.getFloat(KEY_TILT, 0);
         float bearing = preferences.getFloat(KEY_BEARING, 0);
         MapPosition mapPosition = new MapPosition();

--- a/src/main/java/com/mapzen/core/MapzenLocation.java
+++ b/src/main/java/com/mapzen/core/MapzenLocation.java
@@ -91,7 +91,7 @@ public final class MapzenLocation {
 
         @Override
         public void onConnected(Bundle bundle) {
-            getMapController().setZoomLevel(MapController.DEFAULT_ZOOMLEVEL);
+            getMapController().setZoomLevel(MapController.DEFAULT_ZOOM_LEVEL);
             final Location location = locationClient.getLastLocation();
             Logger.d("Last known location: " + location);
 

--- a/src/main/java/com/mapzen/fragment/MapFragment.java
+++ b/src/main/java/com/mapzen/fragment/MapFragment.java
@@ -37,7 +37,7 @@ import android.view.ViewGroup;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapzen.MapController.DEFAULT_ZOOMLEVEL;
+import static com.mapzen.MapController.DEFAULT_ZOOM_LEVEL;
 import static com.mapzen.MapController.getMapController;
 import static com.mapzen.activity.BaseActivity.COM_MAPZEN_UPDATES_LOCATION;
 import static com.mapzen.core.MapzenLocation.COM_MAPZEN_FIND_ME;
@@ -89,7 +89,7 @@ public class MapFragment extends BaseFragment {
     }
 
     public void centerOn(SimpleFeature simpleFeature) {
-        centerOn(simpleFeature, Math.pow(2, DEFAULT_ZOOMLEVEL));
+        centerOn(simpleFeature, Math.pow(2, DEFAULT_ZOOM_LEVEL));
     }
 
     public void centerOn(SimpleFeature simpleFeature, double zoom) {

--- a/src/main/java/com/mapzen/search/PagerResultsFragment.java
+++ b/src/main/java/com/mapzen/search/PagerResultsFragment.java
@@ -39,7 +39,7 @@ import butterknife.OnClick;
 import retrofit.Callback;
 import retrofit.RetrofitError;
 
-import static com.mapzen.MapController.DEFAULT_ZOOMLEVEL;
+import static com.mapzen.MapController.DEFAULT_ZOOM_LEVEL;
 import static com.mapzen.MapController.getMapController;
 import static com.mapzen.android.Pelias.getPelias;
 import static com.mapzen.search.SavedSearch.getSavedSearch;
@@ -162,7 +162,7 @@ public class PagerResultsFragment extends BaseFragment {
     }
 
     private void centerOnPlace(int i) {
-        centerOnPlace(i, Math.pow(2, DEFAULT_ZOOMLEVEL));
+        centerOnPlace(i, Math.pow(2, DEFAULT_ZOOM_LEVEL));
     }
 
     private void centerOnPlace(int i, double zoom) {

--- a/src/test/java/com/mapzen/MapControllerTest.java
+++ b/src/test/java/com/mapzen/MapControllerTest.java
@@ -364,7 +364,7 @@ public class MapControllerTest {
         assertThat(getMapController().getZoomLevel()).isEqualTo(3);
         getMapController().resetZoomAndPointNorth();
         assertThat(getMapController().getZoomLevel())
-                .isEqualTo(getMapController().DEFAULT_ZOOMLEVEL);
+            .isEqualTo(MapController.DEFAULT_ZOOM_LEVEL);
     }
 
     @Test

--- a/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -354,7 +354,7 @@ public class BaseActivityTest {
         getMapController().setZoomLevel(1);
         initLastLocation();
         invokeOnConnected();
-        assertThat(getMapController().getZoomLevel()).isEqualTo(MapController.DEFAULT_ZOOMLEVEL);
+        assertThat(getMapController().getZoomLevel()).isEqualTo(MapController.DEFAULT_ZOOM_LEVEL);
     }
 
     @Test


### PR DESCRIPTION
- Resets zoom to default and sets map orientation north up when the locate me button is clicked. 
