### PR TITLE
Don't rezoom when the app is chilling

### DIFF
--- a/src/main/java/com/mapzen/MapController.java
+++ b/src/main/java/com/mapzen/MapController.java
@@ -145,7 +145,7 @@ public final class MapController {
     }
 
     public double getZoomLevel() {
-        return mapPosition.zoomLevel;
+        return mapPosition.getZoomLevel();
     }
 
     public void setZoomLevel(int zoomLevel) {

--- a/src/main/java/com/mapzen/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/activity/BaseActivity.java
@@ -527,6 +527,7 @@ public class BaseActivity extends MapActivity {
     }
 
     public void locateButtonAction(View view) {
+        app.activateMoveMapToLocation();
         mapFragment.centerOnCurrentLocation();
     }
 

--- a/src/main/java/com/mapzen/fragment/MapFragment.java
+++ b/src/main/java/com/mapzen/fragment/MapFragment.java
@@ -262,9 +262,9 @@ public class MapFragment extends BaseFragment {
     public void findMe() {
         if (mapController.getLocation() != null) {
             addLocationDot();
-            mapController.resetZoomAndPointNorth();
             if (followMe || !initialRelocateHappened) {
                 // TODO find ways to accomplish this without two flags ;(
+                mapController.resetZoomAndPointNorth();
                 initialRelocateHappened = true;
                 getMap().setMapPosition(getUserLocationPosition());
             }

--- a/src/test/java/com/mapzen/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/activity/BaseActivityTest.java
@@ -584,6 +584,14 @@ public class BaseActivityTest {
         assertThat(activity.findViewById(R.id.attribution)).isVisible();
     }
 
+    @Test
+    public void locateButtonAction_shouldActivateMoveMapToLocation() throws Exception {
+        MapzenApplication app = (MapzenApplication) application;
+        app.deactivateMoveMapToLocation();
+        activity.locateButtonAction(activity.findViewById(R.id.locate_button));
+        assertThat(app.shouldMoveMapToLocation()).isTrue();
+    }
+
     private Location initLastLocation() {
         Location location = new Location(GPS_PROVIDER);
         location.setLatitude(1.0);

--- a/src/test/java/com/mapzen/fragment/MapFragmentTest.java
+++ b/src/test/java/com/mapzen/fragment/MapFragmentTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.oscim.core.GeoPoint;
+import org.oscim.core.MapPosition;
 import org.oscim.event.Gesture;
 import org.oscim.layers.marker.ItemizedLayer;
 import org.oscim.layers.marker.MarkerItem;
@@ -284,6 +285,17 @@ public class MapFragmentTest {
     public void onActivityCreated_shouldDoStylesheetDownload() throws Exception {
         FragmentTestUtil.startFragment(mapFragment);
         Mockito.verify(styleDownLoader).download();
+    }
+
+    @Test
+    public void findMe_shouldNotResetZoomAndPointNorthAfterMapPositionEvent() throws Exception {
+        FragmentTestUtil.startFragment(mapFragment);
+        mapFragment.findMe();
+        MapPosition mapPosition = new MapPosition();
+        mapPosition.setZoomLevel(10);
+        activity.getMap().events.fire(Map.POSITION_EVENT, mapPosition);
+        mapFragment.findMe();
+        assertThat(mapFragment.mapController.getZoomLevel()).isEqualTo(10);
     }
 
     private void setTileSourceConfiguration(String source) {


### PR DESCRIPTION
Attempts to solve the issue of when to reposition the map to track the user's current location by manipulating the existing flags:
- MapFragment.followMe
- MapzenApplication.moveMapLocation

There is a larger refactor here that we can attempt if this solution proves inadequate or at some later time:
- Remove duplicate followMe and moveMapLocation flags.
- Move FindMeReceiver into MapController.
- Add logic to MapController to decide whether to reposition the map on location update.
