### PR TITLE
Fix dynamic routing zoom level

### DIFF
--- a/res/values/integers.xml
+++ b/res/values/integers.xml
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="zoom_walking">19</integer>
-    <integer name="zoom_biking">18</integer>
-    <integer name="zoom_driving_0to15">17</integer>
-    <integer name="zoom_driving_15to25">16</integer>
-    <integer name="zoom_driving_25to35">15</integer>
-    <integer name="zoom_driving_35to50">14</integer>
-    <integer name="zoom_driving_over50">13</integer>
+    <integer name="zoom_biking">19</integer>
+    <integer name="zoom_driving_0to15">19</integer>
+    <integer name="zoom_driving_15to25">18</integer>
+    <integer name="zoom_driving_25to35">17</integer>
+    <integer name="zoom_driving_35to50">16</integer>
+    <integer name="zoom_driving_over50">15</integer>
 
-    <integer name="turn_walking">10</integer>
-    <integer name="turn_biking">20</integer>
-    <integer name="turn_driving_0to15">50</integer>
-    <integer name="turn_driving_15to25">100</integer>
-    <integer name="turn_driving_25to35">150</integer>
-    <integer name="turn_driving_35to50">200</integer>
-    <integer name="turn_driving_over50">300</integer>
-
-    <integer name="number_of_locations_for_average_speed">10</integer>
+    <integer name="number_of_locations_for_average_speed">3</integer>
 </resources>

--- a/src/main/java/com/mapzen/MapController.java
+++ b/src/main/java/com/mapzen/MapController.java
@@ -28,8 +28,8 @@ public final class MapController {
     public static final String KEY_BEARING = "rotation";
 
     public static final int DEFAULT_ZOOM_LEVEL = 15;
-    public static final int ROUTE_ZOOM_LEVEL = 17;
     public static final String DEBUG_LOCATION = "fixed_debug_location";
+
     private static MapController mapController;
     private Map map;
     private Location location;
@@ -120,8 +120,9 @@ public final class MapController {
     public MapController quarterOn(Location location, double bearing) {
         ViewController v = map.viewport();
         Float tilt = map.getMapPosition().getTilt();
+        final int zoom = map.getMapPosition().getZoomLevel();
         MapPosition position = new MapPosition(location.getLatitude(), location.getLongitude(),
-                Math.pow(2, ROUTE_ZOOM_LEVEL));
+                Math.pow(2, zoom));
         v.setMapPosition(position);
         map.updateMap(true);
         float[] ext = new float[8];
@@ -166,12 +167,6 @@ public final class MapController {
 
     public void setRotation(float rotation) {
         map.viewport().setRotation(rotation);
-        map.updateMap(true);
-    }
-
-    public void setPosition(Location location) {
-        map.setMapPosition(location.getLatitude(), location.getLongitude(),
-                Math.pow(2, ROUTE_ZOOM_LEVEL));
         map.updateMap(true);
     }
 

--- a/src/test/java/com/mapzen/core/SettingsFragmentTest.java
+++ b/src/test/java/com/mapzen/core/SettingsFragmentTest.java
@@ -183,12 +183,12 @@ public class SettingsFragmentTest {
     @Test
     public void shouldDisplayDefaultZoomValueAsSummary() throws Exception {
         assertThat(findPreferenceById(R.string.settings_zoom_walking_key)).hasSummary("19");
-        assertThat(findPreferenceById(R.string.settings_zoom_biking_key)).hasSummary("18");
-        assertThat(findPreferenceById(R.string.settings_zoom_driving_0to15_key)).hasSummary("17");
-        assertThat(findPreferenceById(R.string.settings_zoom_driving_15to25_key)).hasSummary("16");
-        assertThat(findPreferenceById(R.string.settings_zoom_driving_25to35_key)).hasSummary("15");
-        assertThat(findPreferenceById(R.string.settings_zoom_driving_35to50_key)).hasSummary("14");
-        assertThat(findPreferenceById(R.string.settings_zoom_driving_over50_key)).hasSummary("13");
+        assertThat(findPreferenceById(R.string.settings_zoom_biking_key)).hasSummary("19");
+        assertThat(findPreferenceById(R.string.settings_zoom_driving_0to15_key)).hasSummary("19");
+        assertThat(findPreferenceById(R.string.settings_zoom_driving_15to25_key)).hasSummary("18");
+        assertThat(findPreferenceById(R.string.settings_zoom_driving_25to35_key)).hasSummary("17");
+        assertThat(findPreferenceById(R.string.settings_zoom_driving_35to50_key)).hasSummary("16");
+        assertThat(findPreferenceById(R.string.settings_zoom_driving_over50_key)).hasSummary("15");
     }
 
     @Test
@@ -239,13 +239,13 @@ public class SettingsFragmentTest {
     @Test
     public void shouldInitDefaultValues() throws Exception {
         assertValue(R.string.settings_zoom_walking_key, 19);
-        assertValue(R.string.settings_zoom_biking_key, 18);
-        assertValue(R.string.settings_zoom_driving_0to15_key, 17);
-        assertValue(R.string.settings_zoom_driving_15to25_key, 16);
-        assertValue(R.string.settings_zoom_driving_25to35_key, 15);
-        assertValue(R.string.settings_zoom_driving_35to50_key, 14);
-        assertValue(R.string.settings_zoom_driving_over50_key, 13);
-        assertValue(R.string.settings_number_of_locations_for_average_speed_key, 10);
+        assertValue(R.string.settings_zoom_biking_key, 19);
+        assertValue(R.string.settings_zoom_driving_0to15_key, 19);
+        assertValue(R.string.settings_zoom_driving_15to25_key, 18);
+        assertValue(R.string.settings_zoom_driving_25to35_key, 17);
+        assertValue(R.string.settings_zoom_driving_35to50_key, 16);
+        assertValue(R.string.settings_zoom_driving_over50_key, 15);
+        assertValue(R.string.settings_number_of_locations_for_average_speed_key, 3);
     }
 
     private void assertValue(int id, int value) {


### PR DESCRIPTION
- Update `MapController#quarterOn()` to maintain current zoom level.
- Remove `MapController#setPosition()` method (only used by tests).
- Reduce default number of locations used to calculate average speed to 3.
- Update default routing zoom values in integers.xml.
- Remove unused integer resources for turn radius.
- Remove `MapController.ROUTE_ZOOM_LEVEL` constant. Route zoom level should always come from `ZoomController`.
