### PR TITLE
Show the start of the search query/address/POI in the search bar

### DIFF
--- a/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
+++ b/src/main/java/com/mapzen/search/AutoCompleteAdapter.java
@@ -89,6 +89,7 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
                 searchView.setQuery(tv.getText(), false);
                 mapFragment.clearMarkers();
                 mapFragment.updateMap();
+
                 if (simpleFeature != null) {
                     app.setCurrentSearchTerm(simpleFeature.getHint());
                     mapFragment.centerOn(simpleFeature);
@@ -103,8 +104,11 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
                 } else {
                     searchView.setQuery(tv.getText().toString(), true);
                 }
+
+                act.getQueryAutoCompleteTextView(searchView).setSelection(0);
             }
         });
+
         parent.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View view, MotionEvent motionEvent) {
@@ -112,6 +116,7 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
                 return false;
             }
         });
+
         return textView;
     }
 
@@ -157,6 +162,8 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
             searchView.clearFocus();
             return false;
         }
+
+        act.getQueryAutoCompleteTextView(searchView).setSelection(0);
         return act.executeSearchOnMap(query);
     }
 
@@ -209,6 +216,7 @@ public class AutoCompleteAdapter extends CursorAdapter implements SearchView.OnQ
     public void resetCursor() {
         swapCursor(new MatrixCursor(app.getColumns()));
     }
+
     public void loadSavedSearches() {
         changeCursor(getSavedSearch().getCursor());
     }

--- a/src/test/java/com/mapzen/search/AutoCompleteAdapterTest.java
+++ b/src/test/java/com/mapzen/search/AutoCompleteAdapterTest.java
@@ -26,7 +26,9 @@ import android.support.v4.app.FragmentManager;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.SearchView;
 import android.widget.TextView;
 
 import javax.inject.Inject;
@@ -139,13 +141,13 @@ public class AutoCompleteAdapterTest {
     }
 
     @Test
-    public void onQueryTestSubmit_shouldBeFalse() {
+    public void onQueryTextSubmit_shouldBeFalse() {
         assertThat(adapter.onQueryTextSubmit(baseActivity.getString(R.string.secret_phrase)))
                 .isFalse();
     }
 
     @Test
-    public void onQueryTestSubmit_shouldToggleDebugMode() {
+    public void onQueryTextSubmit_shouldToggleDebugMode() {
         Boolean debugMode = baseActivity.isInDebugMode();
         adapter.onQueryTextSubmit(baseActivity.getString(R.string.secret_phrase));
         assertThat(baseActivity.isInDebugMode()).isNotEqualTo(debugMode);
@@ -223,5 +225,28 @@ public class AutoCompleteAdapterTest {
         view.performClick();
         assertThat(((MapzenApplication) application).getCurrentSearchTerm())
                 .isEqualTo(simpleFeature.getHint());
+    }
+
+    @Test
+    public void onQueryTextSubmit_shouldSetSelection() throws Exception {
+        SearchView searchView = adapter.getSearchView();
+        EditText editText = (EditText) searchView.findViewById(application.getResources()
+                .getIdentifier("android:id/search_src_text", null, null));
+
+        searchView.setQuery("query", false);
+        editText.setSelection(1);
+        adapter.onQueryTextSubmit("query");
+        assertThat(editText).hasSelectionStart(0);
+    }
+
+    @Test
+    public void onClick_shouldSetSelection() throws Exception {
+        SearchView searchView = adapter.getSearchView();
+        EditText editText = (EditText) searchView.findViewById(application.getResources()
+                .getIdentifier("android:id/search_src_text", null, null));
+
+        view.setText("query");
+        view.performClick();
+        assertThat(editText).hasSelectionStart(0);
     }
 }


### PR DESCRIPTION
Repositions the text in the search bar to show the start of the query when search is executed or an auto-complete option is selected. Uses `EditText#setSelection(0)` to move the cursor and reposition the text.
