### PR TITLE
Fix NPE in StyleDownloader when SD card not available

### DIFF
--- a/src/main/java/com/mapzen/open/core/StyleDownLoader.java
+++ b/src/main/java/com/mapzen/open/core/StyleDownLoader.java
@@ -27,9 +27,14 @@ public class StyleDownLoader {
 
     public StyleDownLoader(Context context) {
         this.context = context;
-        File cacheDir = new File(context.getExternalCacheDir().getAbsolutePath()
-                + "/assets");
-        int cacheSize = 1024 * 1024;
+        if (context.getExternalCacheDir() != null) {
+            init();
+        }
+    }
+
+    private void init() {
+        final File cacheDir = new File(context.getExternalCacheDir().getAbsolutePath() + "/assets");
+        final int cacheSize = 1024 * 1024;
         try {
             cache = new HttpResponseCache(cacheDir, cacheSize);
             client = new OkHttpClient();

--- a/src/test/java/com/mapzen/open/core/StyleDownLoaderTest.java
+++ b/src/test/java/com/mapzen/open/core/StyleDownLoaderTest.java
@@ -11,8 +11,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+
+import android.content.Context;
 
 import java.io.File;
 
@@ -81,5 +84,12 @@ public class StyleDownLoaderTest {
             File file = new File(app.getExternalFilesDir(null).getAbsolutePath() + "/" + path);
             assertThat(file).exists();
         }
+    }
+
+    @Test
+    public void shouldVerifyExternalCacheDirectoryIsAvailable() throws Exception {
+        Context mockContext = Mockito.mock(Context.class);
+        Mockito.when(mockContext.getExternalCacheDir()).thenReturn(null);
+        new StyleDownLoader(mockContext);
     }
 }


### PR DESCRIPTION
Checks if external cache directory is available before initializing downloader.
