### PR TITLE
Creates separate profile to include leyndo for local builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,6 +563,35 @@
             </build>
         </profile>
 
+        <profile>
+            <id>leyndo</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.mapzen.android</groupId>
+                    <artifactId>leyndo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <classifier>armeabi</classifier>
+                    <type>so</type>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.mapzen.android</groupId>
+                    <artifactId>leyndo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <classifier>armeabi-v7a</classifier>
+                    <type>so</type>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.mapzen.android</groupId>
+                    <artifactId>leyndo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <classifier>x86</classifier>
+                    <type>so</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
OSM login disabled for local builds by default. To build locally with leyndo enabled use the following command.

`mvn clean install -P leyndo`