### PR TITLE
Prevent NPE due to null support action bar

### DIFF
--- a/src/main/java/com/mapzen/open/route/RoutePreviewFragment.java
+++ b/src/main/java/com/mapzen/open/route/RoutePreviewFragment.java
@@ -123,7 +123,6 @@ public class RoutePreviewFragment extends BaseFragment implements Router.Callbac
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         this.act = (BaseActivity) activity;
-        this.act.getSupportActionBar().hide();
     }
 
     @Override
@@ -144,6 +143,13 @@ public class RoutePreviewFragment extends BaseFragment implements Router.Callbac
         ButterKnife.inject(this, view);
         setOriginAndDestination();
         return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        if (act.getSupportActionBar() != null) {
+            act.getSupportActionBar().hide();
+        }
     }
 
     private void setOriginAndDestination() {

--- a/src/test/java/com/mapzen/open/route/RoutePreviewFragmentTest.java
+++ b/src/test/java/com/mapzen/open/route/RoutePreviewFragmentTest.java
@@ -447,9 +447,9 @@ public class RoutePreviewFragmentTest {
     }
 
     @Test
-    public void onAttach_shouldHideActionBar() throws Exception {
+    public void onViewCreated_shouldHideActionBar() throws Exception {
         activity.getSupportActionBar().show();
-        fragment.onAttach(activity);
+        fragment.onViewCreated(fragment.getView(), null);
         assertThat(activity.getSupportActionBar().isShowing()).isFalse();
     }
 


### PR DESCRIPTION
Moves hiding action bar from `onAttach()` to `onViewCreated()` and adds null check.