### PR TITLE
Route preview should default to car icon in landscape mode.

### DIFF
--- a/res/layout-land/route_preview.xml
+++ b/res/layout-land/route_preview.xml
@@ -49,7 +49,7 @@
 
     <ImageButton
         android:id="@+id/routing_circle"
-        android:src="@drawable/ic_start_button"
+        android:src="@drawable/ic_car_start"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
Previously rotating app with car selected would show `ic_start_button` icon instead.