### PR TITLE
Upgrade LOST to version 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>com.mapzen.android</groupId>
             <artifactId>lost</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Prevents crash when switching between network and gps providers due to NoSuchMethodException.