### PR TITLE
Post delayed runnable to show view all action

### DIFF
--- a/src/main/java/com/mapzen/open/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/open/activity/BaseActivity.java
@@ -46,6 +46,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceFragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.view.MenuItemCompat;
@@ -363,9 +364,13 @@ public class BaseActivity extends ActionBarActivity {
     }
 
     public void showActionViewAll() {
-        if (activityMenu != null) {
-            activityMenu.findItem(R.id.action_view_all).setVisible(true);
-        }
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            @Override public void run() {
+                if (activityMenu != null) {
+                    activityMenu.findItem(R.id.action_view_all).setVisible(true);
+                }
+            }
+        }, 100);
     }
 
     private void resetSearchView() {

--- a/src/test/java/com/mapzen/open/search/PagerResultsFragmentTest.java
+++ b/src/test/java/com/mapzen/open/search/PagerResultsFragmentTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 import org.oscim.core.MapPosition;
+import org.robolectric.Robolectric;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowNetworkInfo;
 import org.robolectric.shadows.ShadowToast;
@@ -203,6 +204,7 @@ public class PagerResultsFragmentTest {
         fragment.add(new SimpleFeature());
         fragment.add(new SimpleFeature());
         fragment.displayResults(2, 0);
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
         assertThat(menu.findItem(R.id.action_view_all)).isVisible();
     }
 


### PR DESCRIPTION
Fixes issue where action view all is not shown after rotating the device. Adds a delayed runnable to give `activityMenu` time to be recreated after rotation before setting visibility.