### PR TITLE
Always cleanup location listener when activity destroyed

### DIFF
--- a/src/main/java/com/mapzen/open/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/open/activity/BaseActivity.java
@@ -143,7 +143,11 @@ public class BaseActivity extends ActionBarActivity {
         if (getMap() != null) {
             ((AndroidMap) getMap()).pause(false);
         }
-        locationClient.connect();
+
+        if (!locationClient.isConnected()) {
+            locationClient.connect();
+        }
+
         MapzenLocation.onLocationServicesConnected(MapController.getMapController(),
                 LocationServices.FusedLocationApi, app);
     }

--- a/src/main/java/com/mapzen/open/activity/BaseActivity.java
+++ b/src/main/java/com/mapzen/open/activity/BaseActivity.java
@@ -151,6 +151,8 @@ public class BaseActivity extends ActionBarActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        locationClient.disconnect();
+
         if (getMap() != null) {
             getMap().destroy();
         }

--- a/src/test/java/com/mapzen/open/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/open/activity/BaseActivityTest.java
@@ -240,6 +240,20 @@ public class BaseActivityTest {
     }
 
     @Test
+    public void onResume_shouldCheckIfConnectedBeforeConnectingAgain() throws Exception {
+        ShadowLocationManager shadowLocationManager = shadowOf(getLocationManager());
+        List<android.location.LocationListener>
+                listeners = shadowLocationManager.getRequestLocationUpdateListeners();
+        for (android.location.LocationListener listener : listeners) {
+            shadowLocationManager.removeUpdates(listener);
+        }
+
+        activity.locationClient.connect();
+        activity.onResume();
+        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
+    }
+
+    @Test
     public void onResume_shouldGetWritableLocationDatabase() throws Exception {
         assertThat(db).isOpen();
     }

--- a/src/test/java/com/mapzen/open/activity/BaseActivityTest.java
+++ b/src/test/java/com/mapzen/open/activity/BaseActivityTest.java
@@ -522,6 +522,12 @@ public class BaseActivityTest {
     }
 
     @Test
+    public void onDestroy_shouldDisconnectLocationClient() throws Exception {
+        activity.onDestroy();
+        assertThat(shadowOf(getLocationManager()).getRequestLocationUpdateListeners()).isEmpty();
+    }
+
+    @Test
     public void onCreateOptionsMenu_shouldRestoreCurrentSearchTerm() throws Exception {
         app.setCurrentSearchTerm("query");
         activity.onCreateOptionsMenu(menu);

--- a/src/test/java/com/mapzen/open/core/MapzenLocationTest.java
+++ b/src/test/java/com/mapzen/open/core/MapzenLocationTest.java
@@ -51,6 +51,7 @@ public class MapzenLocationTest {
     public void setup() {
         application = (MapzenApplication) Robolectric.application;
         application.inject(this);
+        LocationServices.FusedLocationApi = null;
         mapController.setActivity(TestHelper.initBaseActivity());
         listener = new MapzenLocation.Listener(application);
     }


### PR DESCRIPTION
Prevents duplicate location listeners on rotation